### PR TITLE
fix: Make BaseCLIPrompt abstract

### DIFF
--- a/src/main/java/de/dhbw/karlsruhe/students/mailflow/external/infrastructure/cli/BaseCLIPrompt.java
+++ b/src/main/java/de/dhbw/karlsruhe/students/mailflow/external/infrastructure/cli/BaseCLIPrompt.java
@@ -14,7 +14,7 @@ import java.util.Scanner;
  *
  * @author Jonas-Karl, jens1o
  */
-public class BaseCLIPrompt implements Server {
+public abstract class BaseCLIPrompt implements Server {
   private static final int MAX_ATTEMPTS = 3;
   private final BaseCLIPrompt previousPrompt;
   private int attemptCount;


### PR DESCRIPTION
It does not provide any functionality on its own, so `new BaseCLIPrompt()` makes no sense and should be forbidden :)