### PR TITLE
Unwanted warning when loading settings

### DIFF
--- a/src/main/java/de/dhbw/karlsruhe/students/mailflow/external/infrastructure/preferences/FileUserSettingsRepository.java
+++ b/src/main/java/de/dhbw/karlsruhe/students/mailflow/external/infrastructure/preferences/FileUserSettingsRepository.java
@@ -35,12 +35,16 @@ public class FileUserSettingsRepository implements UserSettingsRepository {
     fileHelper = new FileHelper();
   }
 
+  private UserSettings getDefaultSettings(Address address) {
+    return new UserSettings(address, "");
+  }
+
   private void initFile(Address address) throws IOException {
 
     if (fileHelper.existsFile(USERS_SETTINGS_FILE)) {
       return;
     }
-    Set<UserSettings> userSettings = Set.of(new UserSettings(address, ""));
+    Set<UserSettings> userSettings = Set.of(getDefaultSettings(address));
     defaultFileContent = gson.toJson(userSettings);
     fileHelper.saveToFile(USERS_SETTINGS_FILE, defaultFileContent);
   }
@@ -89,6 +93,6 @@ public class FileUserSettingsRepository implements UserSettingsRepository {
     return usersSettings.stream()
         .filter(userSettings -> userSettings.address().equals(address))
         .findFirst()
-        .orElseThrow(() -> new LoadSettingsException("Could not find user settings"));
+        .orElse(getDefaultSettings(address));
   }
 }


### PR DESCRIPTION
fix: do not print warning, when no settings were found for a user. In…stead, we return a default setting.

Error occured when:
1. One user has already saved usersettings
2. another user tries sending an email without any specified signature

Now we just return a default UserSettings object